### PR TITLE
Support async tools (tools that return promises)

### DIFF
--- a/R/coro-utils.R
+++ b/R/coro-utils.R
@@ -48,6 +48,18 @@ async_generator_method <- function(func) {
   deferred_method_transform(fn, coro::async_generator, parent.frame())
 }
 
+async_method <- function(func) {
+  fn <- rlang::enexpr(func)
+
+  stopifnot(
+    "async methods must have `self` parameter" = identical(names(formals(func))[1], "self")
+  )
+  stopifnot(
+    "async methods must have `private` parameter" = identical(names(formals(func))[2], "private")
+  )
+
+  deferred_method_transform(fn, coro::async, parent.frame())
+}
 # Takes a quoted function expression and a transformer function, and returns a
 # function that will _lazily_ transform the lambda function using `transformer`
 # upon first call. This is necessary because the transformation needs to be done

--- a/R/tools.R
+++ b/R/tools.R
@@ -11,6 +11,9 @@ call_tools <- function(tools, message) {
     } else {
       args <- jsonlite::fromJSON(fun$arguments)
       result <- call_tool(tool_fun, args)
+      if (promises::is.promise(result)) {
+        stop("An async tool was used with `chat()` or `stream()`. Async tools are supported, but you must call `chat_async()` or `stream_async()` instead.")
+      }
     }
 
     list(
@@ -20,6 +23,35 @@ call_tools <- function(tools, message) {
     )
   })
 }
+
+call_tools_async <- NULL
+rlang::on_load(call_tools_async <- coro::async(function(tools, message) {
+  if (!has_name(message, "tool_calls")) {
+    return()
+  }
+
+  # We call it this way instead of a more natural for/await because we want to
+  # run all the async tool calls in parallel
+  result_promises <- lapply(message$tool_calls, function(call) {
+    fun <- call$`function`
+    tool_fun <- tools[[fun$name]]
+    p <- if (is.null(tool_fun)) {
+      promises::promise_resolve(paste0("Error calling tool: Unknown tool name '", call$`function`, "'"))
+    } else {
+      args <- jsonlite::fromJSON(fun$arguments)
+      call_tool_async(tool_fun, args)
+    }
+    promises::then(p, function(result) {
+      list(
+        role = "tool",
+        content = toString(result),
+        tool_call_id = call$id
+      )
+    })
+  })
+
+  promises::promise_all(.list = result_promises)
+}))
 
 # Should we check `fun` against registered tools?
 # Also need to handle edge caess: https://platform.openai.com/docs/guides/function-calling/edge-cases
@@ -32,6 +64,19 @@ call_tool <- function(fun, arguments) {
     }
   )
 }
+
+# Should we check `fun` against registered tools?
+# Also need to handle edge caess: https://platform.openai.com/docs/guides/function-calling/edge-cases
+call_tool_async <- NULL
+rlang::on_load(call_tool_async <- coro::async(function(fun, arguments) {
+  tryCatch(
+    await(do.call(fun, arguments)),
+    error = function(e) {
+      # TODO: We need to report this somehow; it's way too hidden from the user
+      paste0("Error calling tool: ", conditionMessage(e))
+    }
+  )
+}))
 
 help_to_text <- function(help_files) {
   file_contents <- NULL

--- a/README.Rmd
+++ b/README.Rmd
@@ -260,7 +260,7 @@ Let's test it:
 get_current_time()
 ```
 ```
-[1] "2024-09-18 17:17:14 UTC"
+[1] "2024-09-18 17:47:14 UTC"
 ```
 
 ### Registering tools

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Let’s test it:
 get_current_time()
 ```
 
-    [1] "2024-09-18 17:17:14 UTC"
+    [1] "2024-09-18 17:47:14 UTC"
 
 ### Registering tools
 

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -46,8 +46,12 @@ test_that("repeated tool calls (async)", {
     list("tz" = tool_arg(type = "string", description = "Time zone", required = TRUE)),
     strict = TRUE
   )
+  # An async tool
   chat_async$register_tool(
-    fun = function(n, mean, sd) { promises::promise_resolve(not_actually_random_number) },
+    fun = coro::async(function(n, mean, sd) {
+      await(coro::async_sleep(0.2))
+      not_actually_random_number
+    }),
     name = "rnorm",
     description = "Drawn numbers from a random normal distribution",
     arguments = list(

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -47,7 +47,7 @@ test_that("repeated tool calls (async)", {
     strict = TRUE
   )
   chat_async$register_tool(
-    fun = function(n, mean, sd) { not_actually_random_number },
+    fun = function(n, mean, sd) { promises::promise_resolve(not_actually_random_number) },
     name = "rnorm",
     description = "Drawn numbers from a random normal distribution",
     arguments = list(
@@ -66,4 +66,7 @@ test_that("repeated tool calls (async)", {
   expect_identical(paste(result, collapse = ""), "2020-08-01T11:00:00\n")
 
   expect_snapshot(chat_async)
+
+  # Can't use async tools with sync methods
+  expect_error(chat_async$chat("Great. Do it again."), "chat_async")
 })


### PR DESCRIPTION
This makes it possible to have long-running async tools that don't block the R thread (though they do block the conversation, of course). You could use mirai/future, or `httr2::req_perform_promise` in a tool.

I'm sorry that I again need to introduce a number of parallel `_async` functions. Just the world we're living in right now.