### PR TITLE
Reduce test duplication by extracting repeated code out into functions

### DIFF
--- a/tests/testthat/_snaps/provider-claude.md
+++ b/tests/testthat/_snaps/provider-claude.md
@@ -1,4 +1,9 @@
-# can make an async tool call
+# defaults are reported
+
+    Code
+      . <- chat_claude()
+
+# all tool variations work
 
     Code
       chat$chat("Great. Do it again.")
@@ -7,10 +12,10 @@
       ! Can't use async tools with `$chat()` or `$stream()`.
       i Async tools are supported, but you must use `$chat_async()` or `$stream_async()`.
 
-# can use inline images
+# can use images
 
     Code
-      . <- chat$chat("What's in this image?", remote_image)
+      . <- chat$chat("What's in this image?", image_remote)
     Condition
       Error:
       ! Claude doesn't support remote images

--- a/tests/testthat/_snaps/provider-gemini.md
+++ b/tests/testthat/_snaps/provider-gemini.md
@@ -1,4 +1,11 @@
-# can make an async tool call
+# defaults are reported
+
+    Code
+      . <- chat_gemini()
+    Message
+      Using model = "gemini-1.5-flash".
+
+# all tool variations work
 
     Code
       chat$chat("Great. Do it again.")
@@ -7,7 +14,7 @@
       ! Can't use async tools with `$chat()` or `$stream()`.
       i Async tools are supported, but you must use `$chat_async()` or `$stream_async()`.
 
-# can use images (inline and remote)
+# can use images
 
     Code
       . <- chat$chat("What's in this image?", image_remote)

--- a/tests/testthat/_snaps/provider-openai.md
+++ b/tests/testthat/_snaps/provider-openai.md
@@ -1,11 +1,11 @@
-# default model is reported
+# defaults are reported
 
     Code
-      . <- chat_openai()$chat("Hi")
+      . <- chat_openai()
     Message
       Using model = "gpt-4o-mini".
 
-# can make an async tool call
+# all tool variations work
 
     Code
       chat$chat("Great. Do it again.")

--- a/tests/testthat/helper-provider.R
+++ b/tests/testthat/helper-provider.R
@@ -1,3 +1,21 @@
+retry_test <- function(code, retries = 1) {
+  code <- enquo(code)
+
+  i <- 1
+  while (i <= retries) {
+    tryCatch(
+      {
+        return(eval(get_expr(code), get_env(code)))
+        break
+      },
+      expectation_failure = function(cnd) NULL
+    )
+    i <- i + 1
+  }
+
+  eval(get_expr(code), get_env(code))
+}
+
 # Turns ------------------------------------------------------------------
 
 test_turns_system <- function(chat_fun) {

--- a/tests/testthat/helper-provider.R
+++ b/tests/testthat/helper-provider.R
@@ -1,0 +1,123 @@
+# Turns ------------------------------------------------------------------
+
+test_turns_system <- function(chat_fun) {
+  system_prompt <- "Return very minimal output, AND ONLY USE UPPERCASE."
+
+  chat <- chat_fun(system_prompt = system_prompt)
+  resp <- chat$chat("What is the name of Winnie the Pooh's human friend?")
+  expect_match(resp, "CHRISTOPHER ROBIN")
+  expect_length(chat$turns(), 2)
+
+  chat <- chat_fun(turns = list(Turn("system", system_prompt)))
+  resp <- chat$chat("What is the name of Winnie the Pooh's human friend?")
+  expect_match(resp, "CHRISTOPHER ROBIN")
+  expect_length(chat$turns(), 2)
+}
+
+test_turns_existing <- function(chat_fun) {
+  chat <- chat_fun(turns = list(
+    Turn("system", "Return very minimal output; no punctuation."),
+    Turn("user", "List the names of any 8 of Santa's 9 reindeer."),
+    Turn("assistant", "Dasher, Dancer, Vixen, Comet, Cupid, Donner, Blitzen, and Rudolph.")
+  ))
+  expect_length(chat$turns(), 2)
+
+  resp <- chat$chat("Who is the remaining one? Just give the name")
+  expect_equal(resp, "Prancer")
+  expect_length(chat$turns(), 4)
+}
+
+
+# Tool calls -------------------------------------------------------------
+
+test_tools_simple <- function(chat_fun) {
+  chat <- chat_fun(system_prompt = "Be very terse, not even punctuation.")
+  chat$register_tool(ToolDef(
+    function() "2024-01-01",
+    name = "get_date",
+    description = "Gets the current date"
+  ))
+
+  result <- chat$chat("What's the current date in YMD format?")
+  expect_match(result, "2024-01-01")
+
+  result <- chat$chat("What month is it?")
+  expect_match(result, "January")
+}
+
+test_tools_async <- function(chat_fun) {
+  chat <- chat_fun(system_prompt = "Be very terse, not even punctuation.")
+  chat$register_tool(ToolDef(
+    coro::async(function() "2024-01-01"),
+    name = "get_date",
+    description = "Gets the current date"
+  ))
+
+  result <- sync(chat$chat_async("What's the current date in YMD format?"))
+  expect_match(result, "2024-01-01")
+
+  expect_snapshot(chat$chat("Great. Do it again."), error = TRUE)
+}
+
+test_tools_parallel <- function(chat_fun) {
+  chat <- chat_fun(system_prompt = "Be very terse, not even punctuation.")
+  favourite_color <- function(person) {
+    if (person == "Joe") "sage green" else "red"
+  }
+  chat$register_tool(ToolDef(
+    function(person) if (person == "Joe") "sage green" else "red",
+    name = "favourite_color",
+    description = "Returns a person's favourite colour",
+    arguments = list(person = ToolArg("string", "Name of a person")),
+    strict = TRUE
+  ))
+
+  result <- chat$chat("
+    What are Joe and Hadley's favourite colours?
+    Answer like name1: colour1, name2: colour2
+  ")
+  expect_identical(result, "Joe: sage green, Hadley: red")
+  expect_length(chat$turns(), 4)
+}
+
+test_tools_sequential <- function(chat_fun) {
+  chat <- chat_fun(system_prompt = "Be very terse, not even punctuation.")
+  chat$register_tool(ToolDef(
+    function() 2024,
+    name = "get_year",
+    description = "Get the current year"
+  ))
+  chat$register_tool(ToolDef(
+    function(year) if (year == 2024) "Susan" else "I don't know",
+    name = "popular_name",
+    description = "Gets the most popular name for a year",
+    arguments = list(year = ToolArg("integer", "Year"))
+  ))
+
+  result <- chat$chat("What was the most popular name this year.")
+  expect_equal(result, "Susan")
+  expect_length(chat$turns(), 6)
+}
+
+
+# Images -----------------------------------------------------------------
+
+test_images_inline <- function(chat_fun) {
+  chat <- chat_fun(model = "gpt-4o-mini")
+  response <- chat$chat(
+    "What's in this image? (Be sure to mention the outside shape)",
+    content_image_file(system.file("httr2.png", package = "elmer"))
+  )
+  expect_match(response, "hex")
+  expect_match(response, "baseball")
+}
+
+test_images_remote <- function(chat_fun) {
+  chat <- chat_fun(model = "gpt-4o-mini")
+  response <- chat$chat(
+    "What's in this image? (Be sure to mention the outside shape)",
+    content_image_url("https://httr2.r-lib.org/logo.png")
+  )
+  expect_match(response, "hex")
+  expect_match(response, "baseball")
+}

--- a/tests/testthat/test-provider-claude.R
+++ b/tests/testthat/test-provider-claude.R
@@ -3,10 +3,13 @@ test_that("can make simple request", {
   resp <- chat$chat("What is 1 + 1?")
   expect_match(resp, "2")
   expect_equal(chat$last_turn()@tokens, c(26, 5))
+})
 
+test_that("can make simple async request", {
+  chat <- chat_claude("Be as terse as possible; no punctuation")
   resp <- sync(chat$chat_async("What is 1 + 1?"))
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens, c(43, 5))
+  expect_equal(chat$last_turn()@tokens, c(26, 5))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-gemini.R
+++ b/tests/testthat/test-provider-gemini.R
@@ -5,10 +5,13 @@ test_that("can make simple request", {
   resp <- chat$chat("What is 1 + 1?")
   expect_match(resp, "2")
   expect_equal(chat$last_turn()@tokens, c(17, 1))
+})
 
+test_that("can make simple async request", {
+  chat <- chat_gemini("Be as terse as possible; no punctuation")
   resp <- sync(chat$chat_async("What is 1 + 1?"))
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens, c(30, 1))
+  expect_equal(chat$last_turn()@tokens, c(17, 1))
 })
 
 test_that("can make simple streaming request", {
@@ -39,7 +42,12 @@ test_that("all tool variations work", {
   test_tools_simple(chat_fun)
   test_tools_async(chat_fun)
   test_tools_parallel(chat_fun)
-  test_tools_sequential(chat_fun, total_calls = 8)
+
+  # <10% of the time, it uses only 6 calls, suggesting that it's made a poor
+  # choice. Running it twice (i.e. retrying 1) should reduce failure rate to <1%
+  retry_test(
+    test_tools_sequential(chat_fun, total_calls = 8)
+  )
 })
 
 test_that("can use images", {

--- a/tests/testthat/test-provider-gemini.R
+++ b/tests/testthat/test-provider-gemini.R
@@ -1,3 +1,5 @@
+# Getting started --------------------------------------------------------
+
 test_that("can make simple request", {
   chat <- chat_gemini("Be as terse as possible; no punctuation")
   resp <- chat$chat("What is 1 + 1?")
@@ -18,113 +20,31 @@ test_that("can make simple streaming request", {
   expect_match(paste0(unlist(resp), collapse = ""), "2")
 })
 
-test_that("system prompt can be passed explicitly or as a turn", {
-  system_prompt <- "Return very minimal output, AND ONLY USE UPPERCASE."
+# Common provider interface -----------------------------------------------
 
-  chat <- chat_gemini(system_prompt = system_prompt)
-  resp <- chat$chat("What is the name of Winnie the Pooh's human friend?")
-  expect_match(resp, "CHRISTOPHER ROBIN")
-
-  chat <- chat_gemini(turns = list(Turn("system", system_prompt)))
-  resp <- chat$chat("What is the name of Winnie the Pooh's human friend?")
-  expect_match(resp, "CHRISTOPHER ROBIN")
+test_that("defaults are reported", {
+  expect_snapshot(. <- chat_gemini())
 })
 
-test_that("existing conversation history is used", {
-  chat <- chat_gemini(turns = list(
-    Turn("system", "Return very minimal output; no punctuation."),
-    Turn("user", "List the names of any 8 of Santa's 9 reindeer."),
-    Turn("assistant", "Dasher, Dancer, Vixen, Comet, Cupid, Donner, Blitzen, and Rudolph.")
-  ))
+test_that("respects turns interface", {
+  chat_fun <- chat_gemini
 
-  resp <- chat$chat("Who is the remaining one? Just give the name")
-  expect_match(resp, "Prancer")
+  test_turns_system(chat_fun)
+  test_turns_existing(chat_fun)
 })
 
-# Tool calls -------------------------------------------------------------------
+test_that("all tool variations work", {
+  chat_fun <- chat_gemini
 
-test_that("can make a simple tool call", {
-  chat <- chat_gemini(system_prompt = "Be very terse, not even punctuation.")
-  chat$register_tool(ToolDef(
-    function() "2024-01-01",
-    name = "get_date",
-    description = "Gets the current date"
-  ))
-
-  result <- chat$chat("What's the current date?")
-  expect_match(result, "2024-01-01")
-
-  result <- chat$chat("What month is it?")
-  expect_match(result, "January")
+  test_tools_simple(chat_fun)
+  test_tools_async(chat_fun)
+  test_tools_parallel(chat_fun)
+  test_tools_sequential(chat_fun, total_calls = 8)
 })
 
-test_that("can make an async tool call", {
-  chat <- chat_gemini(system_prompt = "Be very terse, not even punctuation.")
-  chat$register_tool(ToolDef(
-    coro::async(function() "2024-01-01"),
-    name = "get_date",
-    description = "Gets the current date"
-  ))
+test_that("can use images", {
+  chat_fun <- chat_gemini
 
-  result <- sync(chat$chat_async("What's the current date?"))
-  expect_match(result, "2024-01-01")
-
-  expect_snapshot(chat$chat("Great. Do it again."), error = TRUE)
-})
-
-test_that("can call multiple tools in parallel", {
-  chat <- chat_gemini(system_prompt = "Be very terse, not even punctuation.")
-  chat$register_tool(ToolDef(
-    function(person) if (person == "Joe") "sage green" else "red",
-    name = "favourite_color",
-    description = "Returns a person's favourite colour",
-    arguments = list(person = ToolArg("string", "Name of a person")),
-    strict = TRUE
-  ))
-
-  result <- chat$chat("
-    What are Joe and Hadley's favourite colours?
-    Answer like name1: colour1, name2: colour2
-  ")
-  expect_match(result, "Joe: sage green, Hadley: red")
-  expect_length(chat$turns(), 4)
-})
-
-test_that("can call multiple tools in sequence", {
-  chat <- chat_gemini()
-  chat$register_tool(ToolDef(
-    function() 2024,
-    name = "get_year",
-    description = "Get the current year"
-  ))
-  chat$register_tool(ToolDef(
-    function(year) if (year == 2024) "Susan" else "I don't know",
-    name = "popular_name",
-    description = "Gets the most popular name for a year",
-    arguments = list(year = ToolArg("integer", "Year"))
-  ))
-
-  result <- chat$chat("What's the most popular name this year?")
-  expect_match(result, "Susan")
-  expect_length(chat$turns(), 6)
-})
-
-# Images -----------------------------------------------------------------
-
-test_that("can use images (inline and remote)", {
-  chat <- chat_gemini()
-  response <- chat$chat(
-    "What's in this image? (Be sure to mention the outside shape)",
-    content_image_file(system.file("httr2.png", package = "elmer"))
-  )
-  expect_match(response, "hex")
-  expect_match(response, "baseball")
-  expect_length(chat$turns(), 2)
-
-  image_remote <- content_image_url("https://httr2.r-lib.org/logo.png")
-  expect_snapshot(
-    . <- chat$chat("What's in this image?", image_remote),
-    error = TRUE
-  )
-  expect_length(chat$turns(), 2)
+  test_images_inline(chat_fun)
+  test_images_remote_error(chat_fun)
 })

--- a/tests/testthat/test-provider-openai.R
+++ b/tests/testthat/test-provider-openai.R
@@ -5,10 +5,13 @@ test_that("can make simple request", {
   resp <- chat$chat("What is 1 + 1?")
   expect_match(resp, "2")
   expect_equal(chat$last_turn()@tokens, c(27, 1))
+})
 
+test_that("can make simple async request", {
+  chat <- chat_openai("Be as terse as possible; no punctuation")
   resp <- sync(chat$chat_async("What is 1 + 1?"))
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens, c(44, 1))
+  expect_equal(chat$last_turn()@tokens, c(27, 1))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-openai.R
+++ b/tests/testthat/test-provider-openai.R
@@ -1,6 +1,4 @@
-test_that("default model is reported", {
-  expect_snapshot(. <- chat_openai()$chat("Hi"))
-})
+# Getting started --------------------------------------------------------
 
 test_that("can make simple request", {
   chat <- chat_openai("Be as terse as possible; no punctuation")
@@ -22,121 +20,31 @@ test_that("can make simple streaming request", {
   expect_match(paste0(unlist(resp), collapse = ""), "2")
 })
 
+# Common provider interface -----------------------------------------------
 
-test_that("system prompt can be passed explicitly or as a turn", {
-  system_prompt <- "Return very minimal output, AND ONLY USE UPPERCASE."
-
-  chat <- chat_openai(system_prompt = system_prompt)
-  resp <- chat$chat("What is the name of Winnie the Pooh's human friend?")
-  expect_match(resp, "CHRISTOPHER ROBIN")
-  expect_length(chat$turns(), 2)
-
-  chat <- chat_openai(turns = list(Turn("system", system_prompt)))
-  resp <- chat$chat("What is the name of Winnie the Pooh's human friend?")
-  expect_match(resp, "CHRISTOPHER ROBIN")
-  expect_length(chat$turns(), 2)
+test_that("defaults are reported", {
+  expect_snapshot(. <- chat_openai())
 })
 
-test_that("existing conversation history is used", {
-  chat <- chat_openai(turns = list(
-    Turn("system", "Return very minimal output; no punctuation."),
-    Turn("user", "List the names of any 8 of Santa's 9 reindeer."),
-    Turn("assistant", "Dasher, Dancer, Vixen, Comet, Cupid, Donner, Blitzen, and Rudolph.")
-  ))
-  expect_length(chat$turns(), 2)
+test_that("respects turns interface", {
+  chat_fun <- chat_openai
 
-  resp <- chat$chat("Who is the remaining one? Just give the name")
-  expect_equal(resp, "Prancer")
-  expect_length(chat$turns(), 4)
+  test_turns_system(chat_fun)
+  test_turns_existing(chat_fun)
 })
 
-# Tool calls -------------------------------------------------------------------
+test_that("all tool variations work", {
+  chat_fun <- chat_openai
 
-test_that("can make a simple tool call", {
-  chat <- chat_openai(system_prompt = "Be very terse, not even punctuation.")
-  chat$register_tool(ToolDef(
-    function() "2024-01-01",
-    name = "get_date",
-    description = "Gets the current date"
-  ))
-
-  result <- chat$chat("What's the current date in YMD format?")
-  expect_match(result, "2024-01-01")
-
-  result <- chat$chat("What month is it?")
-  expect_match(result, "January")
+  test_tools_simple(chat_fun)
+  test_tools_async(chat_fun)
+  test_tools_parallel(chat_fun)
+  test_tools_sequential(chat_fun)
 })
 
-test_that("can make an async tool call", {
-  chat <- chat_openai(system_prompt = "Be very terse, not even punctuation.")
-  chat$register_tool(ToolDef(
-    coro::async(function() "2024-01-01"),
-    name = "get_date",
-    description = "Gets the current date"
-  ))
+test_that("can use images", {
+  chat_fun <- chat_openai
 
-  result <- sync(chat$chat_async("What's the current date in YMD format?"))
-  expect_match(result, "2024-01-01")
-
-  expect_snapshot(chat$chat("Great. Do it again."), error = TRUE)
-})
-
-test_that("can call multiple tools in parallel", {
-  chat <- chat_openai(system_prompt = "Be very terse, not even punctuation.")
-  favourite_color <- function(person) {
-    if (person == "Joe") "sage green" else "red"
-  }
-  chat$register_tool(ToolDef(
-    function(person) if (person == "Joe") "sage green" else "red",
-    name = "favourite_color",
-    description = "Returns a person's favourite colour",
-    arguments = list(person = ToolArg("string", "Name of a person")),
-    strict = TRUE
-  ))
-
-  result <- chat$chat("
-    What are Joe and Hadley's favourite colours?
-    Answer like name1: colour1, name2: colour2
-  ")
-  expect_identical(result, "Joe: sage green, Hadley: red")
-  expect_length(chat$turns(), 4)
-})
-
-test_that("can call multiple tools in sequence", {
-  chat <- chat_openai(system_prompt = "Be very terse, not even punctuation.")
-  chat$register_tool(ToolDef(
-    function() 2024,
-    name = "get_year",
-    description = "Get the current year"
-  ))
-  chat$register_tool(ToolDef(
-    function(year) if (year == 2024) "Susan" else "I don't know",
-    name = "popular_name",
-    description = "Gets the most popular name for a year",
-    arguments = list(year = ToolArg("integer", "Year"))
-  ))
-
-  result <- chat$chat("What was the most popular name this year.")
-  expect_equal(result, "Susan")
-  expect_length(chat$turns(), 6)
-})
-
-# Images -----------------------------------------------------------------
-
-test_that("can use images (inline and remote)", {
-  chat <- chat_openai(model = "gpt-4o-mini")
-  response <- chat$chat(
-    "What's in this image? (Be sure to mention the outside shape)",
-    content_image_file(system.file("httr2.png", package = "elmer"))
-  )
-  expect_match(response, "hex")
-  expect_match(response, "baseball")
-
-  chat <- chat_openai(model = "gpt-4o-mini")
-  response <- chat$chat(
-    "What's in this image? (Be sure to mention the outside shape)",
-    content_image_url("https://httr2.r-lib.org/logo.png")
-  )
-  expect_match(response, "hex")
-  expect_match(response, "baseball")
+  test_images_inline(chat_fun)
+  test_images_remote(chat_fun)
 })

--- a/tests/testthat/test-provider-openai.R
+++ b/tests/testthat/test-provider-openai.R
@@ -39,7 +39,7 @@ test_that("all tool variations work", {
   test_tools_simple(chat_fun)
   test_tools_async(chat_fun)
   test_tools_parallel(chat_fun)
-  test_tools_sequential(chat_fun)
+  test_tools_sequential(chat_fun, total_calls = 6)
 })
 
 test_that("can use images", {


### PR DESCRIPTION
I've tried to strike a balance between reducing the duplication in the test code while still making it easy to debug if a test fails. I'm not 100% sure that I've struck the correct balance yet, but I think this breakdown in to tests + functions will make it easier for me to maintain tests of shared behaviour while allowing the backends to vary where needed.

I verified this structure (functions called inside of `test_that()`) blocks yields useful tracebacks.