### PR TITLE
Record NA tokens if OpenAI endpoint doesn't return token details

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # elmer (development version)
 
+* Streaming ollama results works once again (#117).
+
 * Streaming OpenAI results now capture more results, including `logprops` (#115).
 
 * New `interpolate()` and `prompt_file()` make it easier to create prompts that are a mix of static text and dynamic values.

--- a/R/provider-azure.R
+++ b/R/provider-azure.R
@@ -100,10 +100,8 @@ method(chat_request, ProviderAzure) <- function(provider,
 }
 
 method(stream_turn, ProviderAzure) <- function(provider, result) {
-  # Will need to register tokens differently
-  openai_assistant_turn(result$choices[[1]]$delta, result)
+  openai_assistant_turn(provider, result$choices[[1]]$delta, result)
 }
 method(value_turn, ProviderAzure) <- function(provider, result) {
-  # Will need to register tokens differently
-  openai_assistant_turn(result$choices[[1]]$message, result)
+  openai_assistant_turn(provider, result$choices[[1]]$message, result)
 }

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -6,6 +6,7 @@ tokens_log <- function(name, tokens) {
     the$tokens[[name]] <- c(0, 0)
   }
 
+  tokens[is.na(tokens)] <- 0
   the$tokens[[name]] <- the$tokens[[name]] + tokens
   invisible()
 }


### PR DESCRIPTION
And also record `base_url` in the `token_usage()` so you can distinguish different OpenAI compatible endpoints.

Fixes #117