### PR TITLE
add spec to azure for structured output

### DIFF
--- a/R/provider-azure.R
+++ b/R/provider-azure.R
@@ -96,8 +96,6 @@ method(chat_request, ProviderAzure) <- function(provider,
   tools <- unname(lapply(tools, openai_tool))
   extra_args <- utils::modifyList(provider@extra_args, extra_args)
 
-  # TODO: spec
-
   if (!is.null(spec)) {
     response_format <- list(
       type = "json_schema",

--- a/R/provider-azure.R
+++ b/R/provider-azure.R
@@ -98,11 +98,27 @@ method(chat_request, ProviderAzure) <- function(provider,
 
   # TODO: spec
 
+  if (!is.null(spec)) {
+    response_format <- list(
+      type = "json_schema",
+      json_schema = list(
+        name = "structured_data",
+        schema = as_json(provider, spec),
+        strict = TRUE
+      )
+    )
+  } else {
+    response_format <- NULL
+  }
+
   data <- compact(list2(
     messages = messages,
+    model = provider@model,
+    seed = provider@seed,
     stream = stream,
     stream_options = if (stream) list(include_usage = TRUE),
     tools = tools,
+    response_format = response_format,
     !!!extra_args
   ))
   req <- req_body_json(req, data)


### PR DESCRIPTION
This copies the approach in provider-openai.R to enable structured output for azure.

Structured outputs have become my most common usage of LLMs lately. Very excited to see these make their way into elmer.